### PR TITLE
[fix] line12~line25 structural error

### DIFF
--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -10,7 +10,7 @@
                     <button string="New Quotation" name="action_sale_quotations_new" type="object" class="oe_highlight"
                         attrs="{'invisible': ['|', ('type', '=', 'lead'), '&amp;', ('probability', '=', 0), ('active', '=', False)]}"/>
                 </xpath>
-                <button name="action_schedule_meeting" position="after">
+                <xpath expr="//button[@name='action_schedule_meeting']" position="after">
                     <button class="oe_stat_button" type="object"
                         name="action_view_sale_quotation" icon="fa-pencil-square-o" attrs="{'invisible': [('type', '=', 'lead')]}">
                         <field name="quotation_count" widget="statinfo" string="Quotations"/>
@@ -23,7 +23,7 @@
                             <field name="sale_order_count" invisible="1"/>
                         </div>
                     </button>
-                </button>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
not button but xpath

Description of the issue/feature this PR addresses:

Clicking the button will bring in the wrong preset system


Current behavior before PR:
當點選規劃會議時，因為繼承的內容錯誤造成系統會抓取錯誤的內容進行預設搜尋

Desired behavior after PR is merged:
修改後解決問題



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
